### PR TITLE
Add "starting" event and custom delay

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ function Sortable(el, opts){
   opts = opts || {}
   this.delta = opts.delta == null ? 15 : opts.delta
   this.duration = opts.duration || 330
+  this.delay = opts.delay || 100
   this.el = el
   util.touchAction(el, 'none')
   this.pel = util.getRelativeElement(el)
@@ -172,7 +173,7 @@ Sortable.prototype.ontouchstart = function(e) {
     this.el.insertBefore(holder, node)
     this.animate = new Animate(this.pel, node, holder)
     this.emit('start')
-  }.bind(this), 100)
+  }.bind(this), this.delay)
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,6 +139,9 @@ Sortable.prototype.ontouchstart = function(e) {
   if (this.timer) clearTimeout(this.timer)
   var touch = util.getTouch(e)
   if (this._handle) e.preventDefault()
+  this.dragEl = node
+  this.dragging = false
+  this.emit('starting')
   this.timer = setTimeout(function () {
     this.dragEl = node
     this.dragging = true

--- a/test/test.js
+++ b/test/test.js
@@ -313,6 +313,9 @@ describe('.remove()', function () {
     append(2)
     s.bind('li')
     s.unbind()
+    s.on('starting', function () {
+      fired = true
+    })
     s.on('start', function () {
       fired = true
     })

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,18 @@ describe('.bind()', function () {
     })
   })
 
+  it('should bind to element of selector with custom delay', function () {
+    append(5)
+    var s = Sortable(ul, {delay: 200})
+    s.bind('li')
+    var li = ul.querySelector('li')
+    var t = Touch(li)
+    t.start()
+    return t.wait(110).then(function () {
+      assert.equal(s.dragging, false)
+    })
+  })
+
   it('should not bind to element not match', function () {
     append(5)
     var div = document.createElement('div')


### PR DESCRIPTION
Current implementation of `ontouchstart` method comes only with one event emitted - `start`. Which for the most part should be enough. However, there are some edge cases where it is desirable to get element we are about to drag right from the beginning when mousedown is fired,

Also included an option to specify delay time between mousedown and start of dragging.